### PR TITLE
Fix notify-bootstrap.js include path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Include the javascript files in your projects
 
 ```html
 <script src="bower_components/notifyjs/dist/notify.min.js"></script>
-<script src="bower_components/notifyjs/dist/styles/notify-bootstrap.js"></script>
+<script src="bower_components/notifyjs/dist/styles/bootstrap/notify-bootstrap.js"></script>
 ```
 
 ```html


### PR DESCRIPTION
After `bower install angular-notifyjs` the path to `notify-bootstrap.js` is missing the `bootstrap` directory in the README.
